### PR TITLE
Feat/api security traffic generator

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -23,6 +23,11 @@ app.add_middleware(
 )
 
 
+@app.get("/api/health")
+async def health_check():
+    return {"status": "ok"}
+
+
 @app.post("/api/spells")
 async def cast_spell(spell: Spell):
     spell_doc = spell.dict()

--- a/whitesource.config
+++ b/whitesource.config
@@ -1,0 +1,7 @@
+{
+  "scanSettings": {
+    "configMode": "LOCAL",
+    "enableReachability": true,
+	"baseBranches": []
+  }
+}


### PR DESCRIPTION


Adds a lightweight health check endpoint required by the traffic-generator CronJob (api-security demo scenario). The sensor discovers and catalogs this route alongside /api/spells, populating the API endpoint discovery dashboard.