### PR TITLE
Migrate 1Password references to Pattern C tenant naming (SHOW-637/638)

### DIFF
--- a/.github/workflows/build-scan-push.yml
+++ b/.github/workflows/build-scan-push.yml
@@ -65,14 +65,14 @@ jobs:
           REGISTRY_REGION: op://wiz-demo/gar_${{ env.DEPLOY_ENV }}-registry/registryRegion
           WIF_PROVIDER: op://wiz-demo/gar_${{ env.DEPLOY_ENV }}-registry/workloadIdentityProvider
           WIF_SERVICE_ACCOUNT: op://wiz-demo/gar_${{ env.DEPLOY_ENV }}-registry/pusherServiceAccount
-          WIZ_CLIENT_ID: op://wiz-demo/tenant_${{ env.DEPLOY_ENV}}-wizcli-sa/username
-          WIZ_CLIENT_SECRET: op://wiz-demo/tenant_${{ env.DEPLOY_ENV }}-wizcli-sa/password
-          WIZCLI_URL: op://wiz-demo/tenant_${{ env.DEPLOY_ENV }}-wizcli-sa/wizcliUrl
-          WIZ_OS_REGISTRY: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'adv-stg' || 'adv-prod' }}-tenant-info/wizOsRegistryUrl
-          WIZ_OS_USER: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'adv-stg' || 'adv-prod' }}-tenant-info/wizOsRegistryUsername
-          WIZ_OS_PASSWORD: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'adv-stg' || 'adv-prod' }}-tenant-info/wizOsRegistryPassword
-          WIZ_OS_CLIENT_ID: op://wiz-demo/tenant_${{ env.DEPLOY_ENV }}-wizos-apk-credentials/username
-          WIZ_OS_CLIENT_SECRET: op://wiz-demo/tenant_${{ env.DEPLOY_ENV }}-wizos-apk-credentials/credential
+          WIZ_CLIENT_ID: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'stg-advanced' || env.DEPLOY_ENV }}-wizcli-sa/username
+          WIZ_CLIENT_SECRET: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'stg-advanced' || env.DEPLOY_ENV }}-wizcli-sa/password
+          WIZCLI_URL: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'stg-advanced' || env.DEPLOY_ENV }}-wizcli-sa/wizcliUrl
+          WIZ_OS_REGISTRY: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'stg-advanced' || 'advanced' }}-tenant-info/wizOsRegistryUrl
+          WIZ_OS_USER: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'stg-advanced' || 'advanced' }}-tenant-info/wizOsRegistryUsername
+          WIZ_OS_PASSWORD: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'stg-advanced' || 'advanced' }}-tenant-info/wizOsRegistryPassword
+          WIZ_OS_CLIENT_ID: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'stg-advanced' || env.DEPLOY_ENV }}-wizos-apk-credentials/username
+          WIZ_OS_CLIENT_SECRET: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'stg-advanced' || env.DEPLOY_ENV }}-wizos-apk-credentials/credential
 
       # - name: Normalize IMAGE_NAME for file paths
       #   run: |


### PR DESCRIPTION
## Summary
Updates `op://wiz-demo/...` URIs in this repo to the new Pattern C 1Password
item names (matches the `infrastructure/wiz/<tenant-short-name>` directory
naming used by `wiz-demo-infra`).

| Before (legacy) | After (Pattern C) |
|---|---|
| `tenant_adv-stg-tenant-info` | `tenant_stg-advanced-tenant-info` |
| `tenant_adv-prod-tenant-info` | `tenant_advanced-tenant-info` |
| `tenant_adv-sa` | `tenant_advanced-sa` |
| `tenant_adv-stg-sa` | `tenant_stg-advanced-sa` |
| `tenant_stgadvanced-wizcli-sa` | `tenant_stg-advanced-wizcli-sa` |
| `tenant_stgadvanced-wizos-apk-credentials` | `tenant_stg-advanced-wizos-apk-credentials` |

The new items already exist in 1Password — they were created as duplicates of
the legacy items as part of SHOW-637 Phase A. The legacy items remain in place
(now tagged `legacy` in 1Password) and will only be deleted in Phase C after
every consumer repo has merged a PR like this one.

This is the minimum viable change: only the 1P URI item names are translated.
Workflow input values (`stgadvanced`, `advanced`) and control flow are left
alone to keep the diff scoped to 1P naming.

## Context
- Epic: SHOW-94 (Update 1Password Vault wiz-demo)
- Schema ticket: SHOW-637 (Update Naming schema) — Phase A (duplicate) done, Phase B (this PR + sibling PRs)
- Consumer ticket: SHOW-638 (Update dependent resources based on DEMO-334)

## Test plan
- [ ] Manually trigger affected workflows for each `DEPLOY_ENV` value and confirm secrets resolve