### PR TITLE
Add SCA reachability probe for SHOW-796

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 import subprocess
 import yaml  # Vulnerable PyYAML import!
+import requests
 import logging
 
 from fastapi import FastAPI, HTTPException, Depends
@@ -39,6 +40,16 @@ async def get_all_spells():
     async for spell in db.spells.find():
         spells.append(spell_helper(spell))
     return spells
+
+
+@app.get("/api/reachability-probe")
+async def reachability_probe():
+    try:
+        requests.get("http://127.0.0.1:9", timeout=0.01)
+    except requests.RequestException:
+        pass
+
+    return {"status": "reachability probe complete"}
 
 
 @app.get("/api/execute")

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -5,3 +5,4 @@ python-dotenv~=1.1
 motor~=3.7
 piccolo==1.1.0
 PyYAML==5.3
+requests==2.19.1


### PR DESCRIPTION
## Summary
- Adds a catalog-backed Python SCA Reachability probe for SHOW-796.
- Pins `requests==2.19.1`, which maps to `CVE-2018-18074` in the Python vulnerable-symbol catalog.
- Calls `requests.get()` from a reachable FastAPI endpoint so Wiz can classify the finding as `Reachable Function` after scanning.

## Validation
- Ran `python3 -m py_compile app/main.py`.
- Confirmed Sharon's Python vulnerable-symbol file lists `requests.api.get` as an entry point for the pinned vulnerable version.

## Notes
- The route calls localhost with a tiny timeout and ignores connection failures, so it is intended only as a static reachability signal.

Made with [Cursor](https://cursor.com)