### PR TITLE
Fix SCA reachability probe entrypoint for SHOW-796

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 import subprocess
 import yaml  # Vulnerable PyYAML import!
-import requests
+import requests.api
+import requests.exceptions
 import logging
 
 from fastapi import FastAPI, HTTPException, Depends
@@ -45,8 +46,8 @@ async def get_all_spells():
 @app.get("/api/reachability-probe")
 async def reachability_probe():
     try:
-        requests.get("http://127.0.0.1:9", timeout=0.01)
-    except requests.RequestException:
+        requests.api.get("http://127.0.0.1:9", timeout=0.01)
+    except requests.exceptions.RequestException:
         pass
 
     return {"status": "reachability probe complete"}


### PR DESCRIPTION
## Summary
- Updates the SCA Reachability probe to call `requests.api.get()` directly.
- This matches the Python vulnerable-symbol catalog entry for `requests` / `CVE-2018-18074` instead of relying on the `requests.get()` convenience wrapper.

## Validation
- Ran `python3 -m py_compile app/main.py`.

## Follow-up
- After merge, run a metadata and code scan on the `wiz-demo` GitHub connector and re-check `Reachability == Reachable Function` for `wiz-demo/sorcery-solutions-backend/main`.

Made with [Cursor](https://cursor.com)