### PR TITLE
Force SCA reachability rescan of main (SHOW-796)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -45,6 +45,8 @@ async def get_all_spells():
 
 @app.get("/api/reachability-probe")
 async def reachability_probe():
+    # SHOW-796: exercises requests.api.get so SCA reachability resolves the
+    # vulnerable call path (CVE-2018-18074) from a live API entrypoint.
     try:
         requests.api.get("http://127.0.0.1:9", timeout=0.01)
     except requests.exceptions.RequestException:


### PR DESCRIPTION
## Why

The merge of #32 was skipped by the Wiz GitHub connector with reason
`merge event did not trigger a scan`, so `main` never recomputed SCA
reachability for `requests` (CVE-2018-18074). Manual connector metadata
scans dedupe the source scan (`same sha has been scanned recently`).

## What

Adds a comment to the `/api/reachability-probe` handler in `app/main.py`.
This changes file content -> new SHA -> forces a fresh source scan of
`main` so the reachability call-path is recomputed and the finding shows
`Reachability == Reachable function`.

No behavior change.

Made with [Cursor](https://cursor.com)