### PR TITLE
Pin requests==2.32.3 for SCA reachability (SHOW-796)

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -5,4 +5,4 @@ python-dotenv~=1.1
 motor~=3.7
 piccolo==1.1.0
 PyYAML==5.3
-requests==2.19.1
+requests==2.32.3


### PR DESCRIPTION
## Why

`requests==2.19.1` (from #31/#32) broke the `Build/Scan/Push Containers`
workflow with pip `resolution-too-deep` against the modern FastAPI stack,
so the container image hasn't built since #31.

## What

Bumps the pin to `requests==2.32.3`:
- Resolves cleanly with the existing dependencies (verified via pip dry-run).
- Still vulnerable to **CVE-2024-47081** (fixed in 2.32.4).
- The existing `/api/reachability-probe` already calls `requests.api.get`,
  which is a cataloged entry point reaching the vulnerable
  `requests.utils.get_netrc_auth` symbol -> `Reachability == Reachable function`.

No code change needed; only the dependency version.

Made with [Cursor](https://cursor.com)