### PR TITLE
Pin requests==2.30.0 to restore reachable SCA findings (SHOW-796)

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -5,4 +5,4 @@ python-dotenv~=1.1
 motor~=3.7
 piccolo==1.1.0
 PyYAML==5.3
-requests==2.32.3
+requests==2.30.0


### PR DESCRIPTION
## Why

The previous pin `requests==2.32.3` (#34) accidentally **remediated** the `requests` CVEs that Wiz actually flagged as reachable:
- CVE-2024-35195 — fixed in 2.32.0
- CVE-2023-32681 — fixed in 2.31.0

Result: the Sorcery backend now shows **0 Reachable Function** findings, which defeats the SHOW-796 SCA Reachability demo.

## What

Re-pins to `requests==2.30.0`:
- Still vulnerable to **CVE-2024-35195** and **CVE-2023-32681**, whose vulnerable functions (`HTTPAdapter.send`, `rebuild_proxies`) sit directly on the `requests.api.get` send path.
- The existing `/api/reachability-probe` route already calls `requests.api.get`, so those symbols are reached → `Reachability == Reachable function`.
- Resolves cleanly with the FastAPI stack (verified via pip dry-run) — no build break.

No code change; dependency version only.

Made with [Cursor](https://cursor.com)